### PR TITLE
feat: add exercise API endpoint with logging and error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,4 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+.idea/

--- a/app/app.py
+++ b/app/app.py
@@ -1,6 +1,30 @@
-from flask import Flask, jsonify
+import os
+import requests
+import logging
+import uuid
+import time
+from flask import Flask, jsonify, request
+from dotenv import load_dotenv
+
+from pathlib import Path
+load_dotenv(Path(__file__).parent.parent / '.env')
 
 app = Flask(__name__)
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
+logger = logging.getLogger(__name__)
+
+@app.before_request
+def before_request():
+    request.request_id = str(uuid.uuid4())
+    request.start_time = time.time()
+    logger.info(f"request_id={request.request_id} method={request.method} path={request.path}")
+
+@app.after_request
+def after_request(response):
+    duration = time.time() - request.start_time
+    logger.info(f"request_id={request.request_id} status={response.status_code} duration={duration:.3f}s")
+    return response
 
 @app.route("/health")
 def health():
@@ -8,7 +32,24 @@ def health():
 
 @app.route("/status")
 def status():
-    return jsonify({"status": "running"})
+    return jsonify({"status": "running", "db": "not connected yet"})
+
+@app.route("/exercises")
+def exercises():
+    muscle = request.args.get("muscle", "chest")
+    api_key = os.getenv("EXTERNAL_API_KEY")
+    try:
+        response = requests.get(
+            "https://api.api-ninjas.com/v1/exercises",
+            headers={"X-Api-Key": api_key},
+            params={"muscle": muscle},
+            timeout=5
+        )
+        response.raise_for_status()
+        return jsonify(response.json())
+    except requests.exceptions.RequestException as e:
+        logger.error(f"request_id={request.request_id} error={str(e)}")
+        return jsonify({"error": "Could not fetch exercises", "detail": str(e)}), 503
 
 if __name__ == "__main__":
     app.run(debug=True)


### PR DESCRIPTION
## What this PR does
- Adds /exercises endpoint that fetches exercises from API Ninjas by muscle group
- Adds structured logging with request IDs and timing on all requests
- Adds error handling for when the external API is unavailable
- Fixes .env loading path so environment variables are read correctly

## How to test
- Run python app/app.py
- Visit /exercises?muscle=chest to see exercises
- Visit /health and /status to confirm they still work

## Related issues
Closes #3
